### PR TITLE
Bugfix/23 drop unnecessary google chrome privileges

### DIFF
--- a/src/google-chrome/manifest.json
+++ b/src/google-chrome/manifest.json
@@ -82,9 +82,7 @@
         }
     ],
     "permissions": [
-        "storage",
-        "activeTab",
-        "scripting"
+        "storage"
     ],
     "icons": {
         "16": "/images/crowd_helper16.png",


### PR DESCRIPTION
#23 drop unused privileges 'activeTab' and 'scripting'